### PR TITLE
Fork config-server-broker to scs-broker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 push:
-    bin/push-broker
+	bin/push-broker
 
 run:
 	go run ./main.go
 
 manifest:
-    export CONFIG_SERVER_BROKER_CONFIG=$(spruce merge broker_config.yml secrets.yml | spruce json )
+	export SCS_BROKER_CONFIG=$(spruce merge broker_config.yml secrets.yml | spruce json )

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -17,7 +17,7 @@ import (
 	"code.cloudfoundry.org/lager"
 	"github.com/cloudfoundry-community/go-uaa"
 	brokerapi "github.com/pivotal-cf/brokerapi/domain"
-	"github.com/starkandwayne/config-server-broker/config"
+	"github.com/starkandwayne/scs-broker/config"
 	scsccparser "github.com/starkandwayne/spring-cloud-services-cli-config-parser"
 )
 

--- a/cf/broker_config.yml
+++ b/cf/broker_config.yml
@@ -18,3 +18,4 @@
   instance_space_guid: (( param "Please override instance_space_guid" ))
   instance_domain: (( param "Please override instance_domain" ))
   config_server_download_uri: (( param "Please override config_server_download_uri" ))
+  registry_server_download_uri: (( param "Please override registry_server_download_uri" ))

--- a/cf/manifest.yml
+++ b/cf/manifest.yml
@@ -1,6 +1,6 @@
 ---
 applications:
-  - name: config-server-broker
+  - name: scs-broker
     path: ../
     env:
-      CONFIG_SERVER_BROKER_CONFIG: ((config_server_broker_config))
+      SCS_BROKER_CONFIG: ((scs_broker_config))

--- a/config/config.go
+++ b/config/config.go
@@ -6,26 +6,27 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const ConfigEnvVarName string = "CONFIG_SERVER_BROKER_CONFIG"
+const ConfigEnvVarName string = "SCS_BROKER_CONFIG"
 
 type Config struct {
-	ReleaseTag              string   `yaml:"config_server_release_tag"`
-	Auth                    Auth     `yaml:"broker_auth"`
-	ServiceName             string   `yaml:"service_name"`
-	ServiceID               string   `yaml:"service_id"`
-	BasicPlanId             string   `yaml:"basic_plan_id"`
-	BasicPlanName           string   `yaml:"basic_plan_name"`
-	CfConfig                CfConfig `yaml:"cloud_foundry_config"`
-	Description             string   `yaml:"description"`
-	LongDescription         string   `yaml:"long_description"`
-	ProviderDisplayName     string   `yaml:"provider_display_name"`
-	DocumentationURL        string   `yaml:"documentation_url"`
-	SupportURL              string   `yaml:"support_url"`
-	DisplayName             string   `yaml:"display_name"`
-	IconImage               string   `yaml:"icon_image"`
-	InstanceSpaceGUID       string   `yaml:"instance_space_guid"`
-	InstanceDomain          string   `yaml:"instance_domain"`
-	ConfigServerDownloadURI string   `yaml:"config_server_download_uri"`
+	ReleaseTag                string   `yaml:"config_server_release_tag"`
+	Auth                      Auth     `yaml:"broker_auth"`
+	ServiceName               string   `yaml:"service_name"`
+	ServiceID                 string   `yaml:"service_id"`
+	BasicPlanId               string   `yaml:"basic_plan_id"`
+	BasicPlanName             string   `yaml:"basic_plan_name"`
+	CfConfig                  CfConfig `yaml:"cloud_foundry_config"`
+	Description               string   `yaml:"description"`
+	LongDescription           string   `yaml:"long_description"`
+	ProviderDisplayName       string   `yaml:"provider_display_name"`
+	DocumentationURL          string   `yaml:"documentation_url"`
+	SupportURL                string   `yaml:"support_url"`
+	DisplayName               string   `yaml:"display_name"`
+	IconImage                 string   `yaml:"icon_image"`
+	InstanceSpaceGUID         string   `yaml:"instance_space_guid"`
+	InstanceDomain            string   `yaml:"instance_domain"`
+	ConfigServerDownloadURI   string   `yaml:"config_server_download_uri"`
+	RegistryServerDownloadURI string   `yaml:"registry_server_download_uri"`
 }
 
 type Auth struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/starkandwayne/config-server-broker
+module github.com/starkandwayne/scs-broker
 
 go 1.14
 

--- a/httpartifacttransport/filetransport.go
+++ b/httpartifacttransport/filetransport.go
@@ -7,8 +7,8 @@ import (
 	"os"
 
 	"code.cloudfoundry.org/lager"
-	"github.com/starkandwayne/config-server-broker/broker"
-	"github.com/starkandwayne/config-server-broker/config"
+	"github.com/starkandwayne/scs-broker/broker"
+	"github.com/starkandwayne/scs-broker/config"
 )
 
 type HttpArtifactTransport struct {

--- a/main.go
+++ b/main.go
@@ -7,9 +7,9 @@ import (
 
 	"code.cloudfoundry.org/lager"
 	"github.com/pivotal-cf/brokerapi"
-	"github.com/starkandwayne/config-server-broker/broker"
-	"github.com/starkandwayne/config-server-broker/config"
-	"github.com/starkandwayne/config-server-broker/httpartifacttransport"
+	"github.com/starkandwayne/scs-broker/broker"
+	"github.com/starkandwayne/scs-broker/config"
+	"github.com/starkandwayne/scs-broker/httpartifacttransport"
 )
 
 var brokerLogger lager.Logger
@@ -17,7 +17,7 @@ var httpTransport httpartifacttransport.HttpArtifactTransport
 
 func main() {
 
-	brokerLogger = lager.NewLogger("config-server-broker")
+	brokerLogger = lager.NewLogger("scs-broker")
 	brokerLogger.RegisterSink(lager.NewWriterSink(os.Stdout, lager.DEBUG))
 	brokerLogger.RegisterSink(lager.NewWriterSink(os.Stderr, lager.ERROR))
 


### PR DESCRIPTION
So as to create a unified broker without possibly breaking those who use the config-server-specific broker, we've elected to fork the project for unified work. Here's what we've done to make that happen:

* Created the scs-broker repo, pushed the last complete state of config-server-broker to it
* Updated all imports to import from scs-broker rather than config-server-broker
* Updated config with registry-server-specific vars (`registry_server_download_uri`)
* Changed `CONFIG_SERVER_BROKER_CONFIG` to `SCS_BROKER_CONFIG`
