### PR TITLE
Fix broker bugs around plan checks and services

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -13,69 +13,52 @@ const (
 	ArtifactsDir string = "artifacts"
 )
 
-type ConfigServerBroker struct {
+type SCSBroker struct {
 	Config config.Config
 	Logger lager.Logger
 }
 
-func (broker *ConfigServerBroker) Services(ctx context.Context) ([]brokerapi.Service, error) {
-	planList := []brokerapi.ServicePlan{
-		{
-			ID:          "default",
-			Name:        "default",
-			Description: "This plan provides SCS servers deployed to cf",
-			Metadata: &brokerapi.ServicePlanMetadata{
-				DisplayName: "Default",
-			},
-		}}
-
-	configServer := brokerapi.Service{
-		//ID:          broker.Config.ServiceID,
-		//Name:        broker.Config.ServiceName,
-		//Description: broker.Config.Description,
-		ID:          "config-server",
-		Name:        "config-server",
-		Description: "Broker to create config-servers",
-		Bindable:    true,
-		Plans:       planList,
-		Metadata: &brokerapi.ServiceMetadata{
-			//DisplayName:         broker.Config.DisplayName,
-			DisplayName:         "config-server",
-			LongDescription:     broker.Config.LongDescription,
-			DocumentationUrl:    broker.Config.DocumentationURL,
-			SupportUrl:          broker.Config.SupportURL,
-			ImageUrl:            fmt.Sprintf("data:image/png;base64,%s", broker.Config.IconImage),
-			ProviderDisplayName: broker.Config.ProviderDisplayName,
-		},
-		Tags: []string{
-			"snw",
-			"config-server",
-		},
+func (broker *SCSBroker) GetServiceByServiceID(serviceID string) (config.Service, error) {
+	for _, service := range broker.Config.Services {
+		if service.ServiceID == serviceID {
+			return service, nil
+		}
 	}
 
-	registryServer := brokerapi.Service{
-		ID:          "registry-server",
-		Name:        "registry-server",
-		Description: "Broker to create registry-servers",
-		Bindable:    true,
-		Plans: []brokerapi.ServicePlan{
-		{
-			ID:          "basic",
-			Name:        "basic",
-			Description: "This plan provides SCS registry servers deployed to cf",
-			Metadata: &brokerapi.ServicePlanMetadata{
-				DisplayName: "Basic",
+	return config.Service{}, fmt.Errorf("No valid service found for %s", serviceID)
+}
+
+func (broker *SCSBroker) Services(ctx context.Context) ([]brokerapi.Service, error) {
+
+	services := []brokerapi.Service{}
+
+	for _, service := range broker.Config.Services {
+		brokerService := brokerapi.Service{
+			ID:          service.ServiceID,
+			Name:        service.ServiceName,
+			Description: service.ServiceDescription,
+			Bindable:    true,
+			Plans: []brokerapi.ServicePlan{
+				{
+					ID:          service.ServicePlanID,
+					Name:        service.ServicePlanName,
+					Description: service.ServiceDescription,
+					Metadata: &brokerapi.ServicePlanMetadata{
+						DisplayName: service.ServicePlanName,
+					},
+				}},
+			Metadata: &brokerapi.ServiceMetadata{
+				DisplayName: service.ServiceName,
+				ImageUrl:    fmt.Sprintf("data:image/png;base64,%s", broker.Config.IconImage),
 			},
-		}},
-		Metadata: &brokerapi.ServiceMetadata{
-			DisplayName: "registry-server",
-			ImageUrl:    fmt.Sprintf("data:image/png;base64,%s", broker.Config.IconImage),
-		},
-		Tags: []string{
-			"snw",
-			"registry-server",
-		},
+			Tags: []string{
+				"snw",
+				service.ServiceName,
+			},
+		}
+		services = append(services, brokerService)
 	}
 
-	return []brokerapi.Service{configServer, registryServer}, nil
+	return services, nil
+
 }

--- a/broker/client.go
+++ b/broker/client.go
@@ -2,11 +2,11 @@ package broker
 
 import (
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3"
-	"github.com/cloudfoundry-community/go-cf-clients-helper"
+	clients "github.com/cloudfoundry-community/go-cf-clients-helper"
 	"github.com/cloudfoundry-community/go-uaa"
 )
 
-func (broker *ConfigServerBroker) getClient() (*ccv3.Client, error) {
+func (broker *SCSBroker) GetClient() (*ccv3.Client, error) {
 
 	config := clients.Config{
 		Endpoint:          broker.Config.CfConfig.ApiUrl,
@@ -22,9 +22,9 @@ func (broker *ConfigServerBroker) getClient() (*ccv3.Client, error) {
 	return session.V3(), err
 }
 
-func (broker *ConfigServerBroker) getUaaClient() (*uaa.API, error) {
+func (broker *SCSBroker) GetUaaClient() (*uaa.API, error) {
 
-	cf, err := broker.getClient()
+	cf, err := broker.GetClient()
 	if err != nil {
 		return nil, err
 	}

--- a/broker/deprovision.go
+++ b/broker/deprovision.go
@@ -5,20 +5,17 @@ import (
 
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccerror"
 	brokerapi "github.com/pivotal-cf/brokerapi/domain"
+	"github.com/starkandwayne/scs-broker/broker/utilities"
 )
 
-func (broker *ConfigServerBroker) Deprovision(ctx context.Context, instanceID string, details brokerapi.DeprovisionDetails, asyncAllowed bool) (brokerapi.DeprovisionServiceSpec, error) {
+func (broker *SCSBroker) Deprovision(ctx context.Context, instanceID string, details brokerapi.DeprovisionDetails, asyncAllowed bool) (brokerapi.DeprovisionServiceSpec, error) {
 	spec := brokerapi.DeprovisionServiceSpec{}
-	kind, err := getKind(details)
-	if err != nil {
-		return spec, err
-	}
 
-	cfClient, err := broker.getClient()
+	cfClient, err := broker.GetClient()
 	if err != nil {
 		return spec, err
 	}
-	appName := makeAppName(kind, instanceID)
+	appName := utilities.MakeAppName(details.ServiceID, instanceID)
 	app, _, err := cfClient.GetApplicationByNameAndSpace(appName, broker.Config.InstanceSpaceGUID)
 	appNotFound := ccerror.ApplicationNotFoundError{Name: appName}
 	if err == appNotFound {

--- a/broker/poll_build.go
+++ b/broker/poll_build.go
@@ -9,13 +9,13 @@ import (
 	"code.cloudfoundry.org/cli/util/configv3"
 )
 
-func (broker *ConfigServerBroker) pollBuild(buildGUID string, appName string) (ccv3.Droplet, ccv3.Warnings, error) {
+func (broker *SCSBroker) pollBuild(buildGUID string, appName string) (ccv3.Droplet, ccv3.Warnings, error) {
 	var allWarnings ccv3.Warnings
 
 	timeout := time.After(configv3.DefaultStagingTimeout)
 	interval := time.NewTimer(0)
 
-	cfClient, err := broker.getClient()
+	cfClient, err := broker.GetClient()
 	if err != nil {
 		return ccv3.Droplet{}, nil, errors.New("couldn't start session: " + err.Error())
 	}

--- a/broker/poll_package.go
+++ b/broker/poll_package.go
@@ -10,9 +10,9 @@ import (
 	"code.cloudfoundry.org/lager"
 )
 
-func (broker *ConfigServerBroker) pollPackage(pkg ccv3.Package) (ccv3.Package, ccv3.Warnings, error) {
+func (broker *SCSBroker) pollPackage(pkg ccv3.Package) (ccv3.Package, ccv3.Warnings, error) {
 	var allWarnings ccv3.Warnings
-	cfClient, err := broker.getClient()
+	cfClient, err := broker.GetClient()
 	if err != nil {
 		return ccv3.Package{}, nil, errors.New("Couldn't start session: " + err.Error())
 	}

--- a/broker/provision.go
+++ b/broker/provision.go
@@ -2,14 +2,13 @@ package broker
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	brokerapi "github.com/pivotal-cf/brokerapi/domain"
 	scsccparser "github.com/starkandwayne/spring-cloud-services-cli-config-parser"
 )
 
-func (broker *ConfigServerBroker) Provision(ctx context.Context, instanceID string, details brokerapi.ProvisionDetails, asyncAllowed bool) (spec brokerapi.ProvisionedServiceSpec, err error) {
+func (broker *SCSBroker) Provision(ctx context.Context, instanceID string, details brokerapi.ProvisionDetails, asyncAllowed bool) (spec brokerapi.ProvisionedServiceSpec, err error) {
 	broker.Logger.Info(fmt.Sprintf("Got these details: %s", details))
 	spec = brokerapi.ProvisionedServiceSpec{}
 	envsetup := scsccparser.EnvironmentSetup{}
@@ -22,28 +21,19 @@ func (broker *ConfigServerBroker) Provision(ctx context.Context, instanceID stri
 		return spec, err
 	}
 
-	if details.PlanID != "basic" {
-		return spec, errors.New("plan_id not recognized")
-	}
-
-	kind, err := getKind(details)
-	if err != nil {
-		return spec, err
-	}
-
-	broker.Logger.Info("Provisioning a " + kind + " service instance")
+	broker.Logger.Info("Provisioning a " + details.ServiceID + " service instance")
 
 	var provisioner func(string, string, string, map[string]string) (string, error)
 
-	switch kind {
-	case "registry-server":
+	switch details.ServiceID {
+	case "service-registry":
 		provisioner = broker.createRegistryServerInstance
 	case "config-server":
 		provisioner = broker.createConfigServerInstance
 
 	}
 
-	url, err := provisioner(kind, instanceID, string(details.RawParameters), mapparams)
+	url, err := provisioner(details.ServiceID, instanceID, string(details.RawParameters), mapparams)
 	if err != nil {
 		return spec, err
 	}

--- a/broker/scale_registry_server.go
+++ b/broker/scale_registry_server.go
@@ -5,7 +5,7 @@ import (
 	"code.cloudfoundry.org/cli/types"
 )
 
-func (broker *ConfigServerBroker) scaleRegistryServer(cfClient *ccv3.Client, app *ccv3.Application, count int, rc *registryConfig) error {
+func (broker *SCSBroker) scaleRegistryServer(cfClient *ccv3.Client, app *ccv3.Application, count int, rc *registryConfig) error {
 	p := ccv3.Process{
 		Type:       "web",
 		Instances:  types.NullInt{Value: count, IsSet: true},

--- a/broker/scs_service_instance.go
+++ b/broker/scs_service_instance.go
@@ -1,0 +1,9 @@
+package broker
+
+type ServiceRegistryInstance struct {
+	SCSBroker *SCSBroker
+}
+
+type scs_instance interface {
+	CreateServerInstance(string, string, string, map[string]string) (string, error)
+}

--- a/broker/show_warnings.go
+++ b/broker/show_warnings.go
@@ -7,7 +7,7 @@ import (
 	"code.cloudfoundry.org/lager"
 )
 
-func (broker *ConfigServerBroker) showWarnings(warnings ccv3.Warnings, subject interface{}) {
+func (broker *SCSBroker) showWarnings(warnings ccv3.Warnings, subject interface{}) {
 	broker.Logger.Info(fmt.Sprintf("NOTICE: %d warning(s) were detected!", len(warnings)), lager.Data{"Subject": subject})
 
 	for warn := range warnings {

--- a/broker/unbind.go
+++ b/broker/unbind.go
@@ -5,25 +5,21 @@ import (
 	"fmt"
 
 	brokerapi "github.com/pivotal-cf/brokerapi/domain"
+	"github.com/starkandwayne/scs-broker/broker/utilities"
 )
 
-func (broker *ConfigServerBroker) Unbind(ctx context.Context, instanceID, bindingID string, details brokerapi.UnbindDetails, asyncAllowed bool) (brokerapi.UnbindSpec, error) {
+func (broker *SCSBroker) Unbind(ctx context.Context, instanceID, bindingID string, details brokerapi.UnbindDetails, asyncAllowed bool) (brokerapi.UnbindSpec, error) {
 	unbind := brokerapi.UnbindSpec{}
 
-	kind, err := getKind(details)
-	if err != nil {
-		return unbind, err
-	}
-
 	broker.Logger.Info("UnBind: GetUAAClient")
-	api, err := broker.getUaaClient()
+	api, err := broker.GetUaaClient()
 	if err != nil {
 		broker.Logger.Info("UnBind: Error in GetUAAClient")
 		return unbind, err
 	}
 
 	broker.Logger.Info("UnBind: makeClientIdForBinding")
-	clientId := makeClientIdForBinding(kind, bindingID)
+	clientId := utilities.MakeClientIdForBinding(details.ServiceID, bindingID)
 
 	broker.Logger.Info(fmt.Sprintf("UnBind: DeleteClient bindingID:%s clientid %s", bindingID, clientId))
 	_, err = api.DeleteClient(clientId)

--- a/broker/unimplemented.go
+++ b/broker/unimplemented.go
@@ -7,18 +7,18 @@ import (
 	brokerapi "github.com/pivotal-cf/brokerapi/domain"
 )
 
-func (broker *ConfigServerBroker) LastOperation(ctx context.Context, instanceID string, details brokerapi.PollDetails) (brokerapi.LastOperation, error) {
+func (broker *SCSBroker) LastOperation(ctx context.Context, instanceID string, details brokerapi.PollDetails) (brokerapi.LastOperation, error) {
 	return brokerapi.LastOperation{}, errors.New("not implemented")
 }
 
-func (broker *ConfigServerBroker) GetBinding(ctx context.Context, instanceID, bindingID string) (brokerapi.GetBindingSpec, error) {
+func (broker *SCSBroker) GetBinding(ctx context.Context, instanceID, bindingID string) (brokerapi.GetBindingSpec, error) {
 	return brokerapi.GetBindingSpec{}, errors.New("not implemented")
 }
 
-func (broker *ConfigServerBroker) GetInstance(ctx context.Context, instanceID string) (brokerapi.GetInstanceDetailsSpec, error) {
+func (broker *SCSBroker) GetInstance(ctx context.Context, instanceID string) (brokerapi.GetInstanceDetailsSpec, error) {
 	return brokerapi.GetInstanceDetailsSpec{}, errors.New("not implemented")
 }
 
-func (broker *ConfigServerBroker) LastBindingOperation(ctx context.Context, instanceID, bindingID string, details brokerapi.PollDetails) (brokerapi.LastOperation, error) {
+func (broker *SCSBroker) LastBindingOperation(ctx context.Context, instanceID, bindingID string, details brokerapi.PollDetails) (brokerapi.LastOperation, error) {
 	return brokerapi.LastOperation{}, errors.New("not implemented")
 }

--- a/broker/update.go
+++ b/broker/update.go
@@ -6,18 +6,12 @@ import (
 	brokerapi "github.com/pivotal-cf/brokerapi/domain"
 )
 
-func (broker *ConfigServerBroker) Update(cxt context.Context, instanceID string, details brokerapi.UpdateDetails, asyncAllowed bool) (brokerapi.UpdateServiceSpec, error) {
-	spec := brokerapi.UpdateServiceSpec{}
-
-	kind, err := getKind(details)
-	if err != nil {
-		return spec, err
-	}
+func (broker *SCSBroker) Update(cxt context.Context, instanceID string, details brokerapi.UpdateDetails, asyncAllowed bool) (brokerapi.UpdateServiceSpec, error) {
 
 	var updater func(context.Context, string, brokerapi.UpdateDetails, bool) (brokerapi.UpdateServiceSpec, error)
 
-	switch kind {
-	case "registry-server":
+	switch details.ServiceID {
+	case "service-registry":
 		updater = broker.updateRegistryServerInstance
 	case "config-server":
 		updater = broker.updateConfigServerInstance

--- a/broker/update_app_environment.go
+++ b/broker/update_app_environment.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Updates the app enviornment variables for creating or updating an instance.
-func (broker *ConfigServerBroker) updateAppEnvironment(cfClient *ccv3.Client, app *ccv3.Application, info *ccv3.Info, kind string, instanceId string, jsonparams string, params map[string]string) error {
+func (broker *SCSBroker) UpdateAppEnvironment(cfClient *ccv3.Client, app *ccv3.Application, info *ccv3.Info, kind string, instanceId string, jsonparams string, params map[string]string) error {
 
 	var profiles []string
 	for key, value := range params {

--- a/broker/utilities/utilities.go
+++ b/broker/utilities/utilities.go
@@ -1,4 +1,4 @@
-package broker
+package utilities
 
 import (
 	"encoding/json"
@@ -21,7 +21,7 @@ var seededRand *rand.Rand = rand.New(
 	rand.NewSource(time.Now().UnixNano()))
 
 // Generate a random password.
-func genClientPassword() string {
+func GenClientPassword() string {
 	b := make([]byte, passwordLength)
 	for i := range b {
 		b[i] = charset[seededRand.Intn(len(charset))]
@@ -32,7 +32,7 @@ func genClientPassword() string {
 // Given a broker request details object, determine
 // which of the supported services the request is
 // about.
-func getKind(details interface{}) (string, error) {
+func GetKind(details interface{}) (string, error) {
 	// fun fact: this whole function is gross.
 	if d, ok := details.(brokerapi.ProvisionDetails); ok {
 		return d.ServiceID, nil
@@ -63,17 +63,17 @@ func getKind(details interface{}) (string, error) {
 
 // Generate a UAA client ID binding name based on the kind of
 // service in question and the binding's  ID.
-func makeClientIdForBinding(kind string, bindingId string) string {
-	return kind + "-binding-" + strings.Replace(bindingId, kind+"-", "", 1)
+func MakeClientIdForBinding(serviceId string, bindingId string) string {
+	return serviceId + "-binding-" + strings.Replace(bindingId, serviceId+"-", "", 1)
 }
 
 // Generate an app name based on the kind of service in question
 // and a service instance ID.
-func makeAppName(kind string, instanceId string) string {
-	return kind + "-" + instanceId
+func MakeAppName(serviceId string, instanceId string) string {
+	return serviceId + "-" + instanceId
 }
 
-func extractRegistryParams(details string) (map[string]interface{}, error) {
+func ExtractRegistryParams(details string) (map[string]interface{}, error) {
 	// decode the raw params
 	decoded := make(map[string]interface{})
 	if err := json.Unmarshal([]byte(details), &decoded); err != nil {
@@ -81,7 +81,7 @@ func extractRegistryParams(details string) (map[string]interface{}, error) {
 	}
 
 	// get the registry-specific params that affect broker operations
-	rp := registryParams{}
+	rp := RegistryParams{}
 
 	rp.Merge("count", decoded)
 	rp.Merge("application-security-groups", decoded)
@@ -92,9 +92,9 @@ func extractRegistryParams(details string) (map[string]interface{}, error) {
 	return rp, nil
 }
 
-type registryParams map[string]interface{}
+type RegistryParams map[string]interface{}
 
-func (rp registryParams) Merge(key string, other map[string]interface{}) {
+func (rp RegistryParams) Merge(key string, other map[string]interface{}) {
 	if value, found := other[key]; found {
 		rp[key] = value
 	}

--- a/cf/broker_config.yml
+++ b/cf/broker_config.yml
@@ -1,13 +1,26 @@
   broker_auth:
     user: (( param "Please override broker_auth.user" ))
     password: (( param "Please override broker_auth.password" ))
-  service_name: config-server
-  service_id: config-server
-  basic_plan_name: default
-  basic_plan_id: default
-  description: Broker to create config-servers
-  long_description: Broker to create config-servers
-  config_server_release_tag: Greenwich.SR3
+  broker_name: scs-broker
+  broker_id: scs-broker
+  description: Broker to create SCS services
+  long_description: Broker to create SCS services
+  instance_space_guid: (( param "Please override instance_space_guid" ))
+  instance_domain: (( param "Please override instance_domain" ))
+  artifacts_directory: "/app/artifacts"
+  services:
+    - service_name: config-server
+      service_id: config-server
+      service_plan_id: default
+      service_plan_name: default
+      service_description: Broker to create config-servers
+      service_download_uri: (( param "Please override config_server_download_uri" ))
+    - service_name: service-registry
+      service_id: service-registry
+      service_plan_id: default
+      service_plan_name: default
+      service_description: Broker to create config-servers
+      service_download_uri: (( param "Please override service_registry_download_uri" ))
   cloud_foundry_config:
     api_url: (( param "Please override cloud_foundry_config.api_url" ))
     skip_ssl_validation: true
@@ -15,7 +28,3 @@
     cf_password: (( param "Please override uaa_config.password" ))
     uaa_client_id: (( param "Please override uaa_config.client_id" ))
     uaa_client_secret: (( param "Please override uaa_config.client_secret" ))
-  instance_space_guid: (( param "Please override instance_space_guid" ))
-  instance_domain: (( param "Please override instance_domain" ))
-  config_server_download_uri: (( param "Please override config_server_download_uri" ))
-  registry_server_download_uri: (( param "Please override registry_server_download_uri" ))

--- a/config/config.go
+++ b/config/config.go
@@ -9,29 +9,35 @@ import (
 const ConfigEnvVarName string = "SCS_BROKER_CONFIG"
 
 type Config struct {
-	ReleaseTag                string   `yaml:"config_server_release_tag"`
-	Auth                      Auth     `yaml:"broker_auth"`
-	ServiceName               string   `yaml:"service_name"`
-	ServiceID                 string   `yaml:"service_id"`
-	BasicPlanId               string   `yaml:"basic_plan_id"`
-	BasicPlanName             string   `yaml:"basic_plan_name"`
-	CfConfig                  CfConfig `yaml:"cloud_foundry_config"`
-	Description               string   `yaml:"description"`
-	LongDescription           string   `yaml:"long_description"`
-	ProviderDisplayName       string   `yaml:"provider_display_name"`
-	DocumentationURL          string   `yaml:"documentation_url"`
-	SupportURL                string   `yaml:"support_url"`
-	DisplayName               string   `yaml:"display_name"`
-	IconImage                 string   `yaml:"icon_image"`
-	InstanceSpaceGUID         string   `yaml:"instance_space_guid"`
-	InstanceDomain            string   `yaml:"instance_domain"`
-	ConfigServerDownloadURI   string   `yaml:"config_server_download_uri"`
-	RegistryServerDownloadURI string   `yaml:"registry_server_download_uri"`
+	Auth                Auth      `yaml:"broker_auth"`
+	BrokerName          string    `yaml:"broker_name"`
+	BrokerID            string    `yaml:"broker_id"`
+	ArtifactsDir        string    `yaml:"artifacts_directory"`
+	CfConfig            CfConfig  `yaml:"cloud_foundry_config"`
+	Description         string    `yaml:"description"`
+	LongDescription     string    `yaml:"long_description"`
+	ProviderDisplayName string    `yaml:"provider_display_name"`
+	DocumentationURL    string    `yaml:"documentation_url"`
+	SupportURL          string    `yaml:"support_url"`
+	DisplayName         string    `yaml:"display_name"`
+	IconImage           string    `yaml:"icon_image"`
+	InstanceSpaceGUID   string    `yaml:"instance_space_guid"`
+	InstanceDomain      string    `yaml:"instance_domain"`
+	Services            []Service `yaml:"services"`
 }
 
 type Auth struct {
 	Username string `yaml:"user"`
 	Password string `yaml:"password"`
+}
+
+type Service struct {
+	ServiceName        string `yaml:"service_name"`
+	ServiceID          string `yaml:"service_id"`
+	ServicePlanID      string `yaml:"service_plan_id"`
+	ServicePlanName    string `yaml:"service_plan_name"`
+	ServiceDescription string `yaml:"service_description"`
+	ServiceDownloadURI string `yaml:"service_download_uri"`
 }
 
 type CfConfig struct {

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func main() {
 
 	brokerLogger.Info("starting")
 
-	serviceBroker := &broker.ConfigServerBroker{
+	serviceBroker := &broker.SCSBroker{
 		Config: brokerConf,
 		Logger: brokerLogger,
 	}


### PR DESCRIPTION
- Fixed issue where expected service plan for the broker was "basic" and would hard fail if other plan was specified. Removed plan checks for now and now allow individual plans to be specified in configuration. This also fixes the magic strings.
- Fixed issue with artifacts directory being relative - has been moved to configuration file to allow for being cloud aware.
- Moved service configuration to config file for support of future services added (if need be) - solves problem of service plan names
- Moved towards interfacing on services rather than static typing for future use. Ideally, services should be configured externally but that is outside the scope and time frame for this particular project/need.
